### PR TITLE
Update users.json.example

### DIFF
--- a/users.json.example
+++ b/users.json.example
@@ -28,5 +28,5 @@
       "username": "lorem",
       "password": "ipsum"
     }
-  },
+  }
 ]


### PR DESCRIPTION
remove last trailing comma to conform to the correct json format

# Description
reference
https://stackoverflow.com/a/201856

The JSON specification does not allow a trailing comma. When users.json.example is copied directly, there will be issue with json decoding.

**Fixes #11 **

## Type of change

- Non-breaking changes. Sample file update

**Test Configuration**:

- OS: MacOS
- Browser: Chrome
- Python version: 3.8.5
